### PR TITLE
added individual page descriptions

### DIFF
--- a/src/components/CategoryView.vue
+++ b/src/components/CategoryView.vue
@@ -1,6 +1,7 @@
 <template>
     <page-wrapper :loaded="loaded">
         <h1>{{label}}</h1>
+        <h2>{{description}}</h2>
         <hr/>
         <article-list :articles="articles" class="list mx-5 mb-4"/>
     </page-wrapper>
@@ -20,7 +21,8 @@ export default {
         return {
             loaded: false,
             articles: [],
-            label: ''
+            label: '',
+            description: ''
         }
     },
     methods: {
@@ -32,6 +34,26 @@ export default {
                 this.label = labelRes.data.data.label
                 document.title = this.label + ' | The Hare'
                 this.loaded = true
+                switch (this.label) {
+                    case 'News':
+                        this.description = 'This definitely happened.';
+                        break;
+                    case 'Features':
+                        this.description = 'Glorious.';
+                        break;
+                    case 'Sports':
+                        this.description = 'Probably the least controversial thing here.';
+                        break;
+                    case 'Art':
+                        this.deescription = 'Our writers are probably on something.'
+                        break;
+                    case 'Rabbithole':
+                        this.description = '60% shit. 50% posts.';
+                        break;
+                    case 'News in Images':
+                        this.description = 'For the illiterate.';
+                        break;
+                }
             } catch (ex) {
                 console.log(ex);
             }
@@ -45,8 +67,15 @@ export default {
 
 <style scoped>
 h1 {
+    text-align: left;
     font-size: 4em;
     font-weight: bold;
+    margin-bottom: 0pt;
+    color: #c12a2a;
+}
+h2 {
+  text-align: left;
+  color: #aaaaaa;
 }
 @media screen and (max-width: 768px) {
     .list {


### PR DESCRIPTION
* Added descriptions to relevant pages (not all of them are being used because the navbar hasn't been updated) 
* Text-aligned title and description to the left (once the 'just-in' section and the ad section are added, title will be aligned to center like photo: 
![image](https://user-images.githubusercontent.com/46540729/90989885-dc16d780-e56a-11ea-9705-a4cbe48a3469.png)

[Screen Recording 2020-08-23 at 5 57 28 PM mov](https://user-images.githubusercontent.com/46540729/90989782-63b01680-e56a-11ea-8496-0626d786d4d8.gif)
